### PR TITLE
auto/keep-running-on-08-07-2024

### DIFF
--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -18,8 +18,8 @@ jobs:
     name: "Test for lib/ changes"
     strategy:
       matrix:
-        otp: [22.2]
-        elixir: [1.10.0]
+        otp: [24.2]
+        elixir: [1.16]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -18,8 +18,8 @@ jobs:
     name: "Test for lib/ changes"
     strategy:
       matrix:
-        otp: [21.3.8, 22.3.4, 23.3.4]
-        elixir: [1.11]
+        otp: [24.2.2]
+        elixir: [1.12]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -18,7 +18,7 @@ jobs:
     name: "Test for lib/ changes"
     strategy:
       matrix:
-        otp: [21, 22, 23]
+        otp: [21.3.8, 22.3.4, 23.3.4]
         elixir: [1.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -18,8 +18,8 @@ jobs:
     name: "Test for lib/ changes"
     strategy:
       matrix:
-        otp: [24.2]
-        elixir: [1.16]
+        otp: [21, 22, 23]
+        elixir: [1.11]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -1,5 +1,9 @@
 name: "Reproducing Test-Case Detector (experimental)"
 
+
+env:
+  ImageOS: ubuntu22
+
 on:
   pull_request:
     paths:
@@ -7,7 +11,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - "run-id=${{ github.run_id }}"
     name: "Test for lib/ changes"
     strategy:
       matrix:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21, 22, 23]
+        otp: [21.3.8, 22.3.4, 23.3.4]
         elixir: [1.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,8 +20,8 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [24.2]
-        elixir: [1.16]
+        otp: [21, 22, 23]
+        elixir: [1.11]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,4 +1,8 @@
 name: "CI Tests"
+
+env:
+  ImageOS: ubuntu22
+
 on:
   push:
     branches:
@@ -9,7 +13,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - "run-id=${{ github.run_id }}"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
       matrix:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,8 +20,8 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21.3.8, 22.3.4, 23.3.4]
-        elixir: [1.11]
+        otp: [24.2.2]
+        elixir: [1.12]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,29 +20,17 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.0]
+        otp: [24.2]
+        elixir: [1.16]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix compile --warnings-as-errors
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix test
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: ./test/smoke_test.sh
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -18,7 +18,7 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21, 22, 23]
+        otp: [21.3.8, 22.3.4, 23.3.4]
         elixir: [1.11]
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.11", "master"]

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -18,10 +18,10 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21.3.8, 22.3.4, 23.3.4]
-        elixir: [1.11]
+        otp: [24.2.2]
+        elixir: [1.12]
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
-        repo_branch: ["v1.11", "master"]
+        repo_branch: ["v1.12", "master"]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -1,4 +1,8 @@
 name: "Compatibility: Elixir"
+
+env:
+  ImageOS: ubuntu22
+
 on:
   push:
     branches:
@@ -6,7 +10,10 @@ on:
 
 jobs:
   test_on_source:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - "run-id=${{ github.run_id }}"
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -18,10 +18,10 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [24.2]
-        elixir: [1.16]
+        otp: [21, 22, 23]
+        elixir: [1.11]
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
-        repo_branch: ["v1.16", "master"]
+        repo_branch: ["v1.11", "master"]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -18,33 +18,20 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.0]
+        otp: [24.2]
+        elixir: [1.16]
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
-        repo_branch: ["v1.10", "master"]
+        repo_branch: ["v1.16", "master"]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mkdir -p tmp
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: git clone ${{matrix.repo_url}} tmp/${{matrix.repo_branch}} --depth=1 --branch ${{matrix.repo_branch}}
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix credo tmp/${{matrix.repo_branch}} --strict --mute-exit-status
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -24,7 +24,7 @@ jobs:
         repo_branch: ["v1.16", "master"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -24,7 +24,7 @@ jobs:
         repo_branch: ["v1.16", "master"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -17,36 +17,22 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.0]
+        otp: [24.2]
+        elixir: [1.16]
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mkdir -p tmp
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: git clone ${{matrix.repo_url}} tmp/${{matrix.repo_branch}} --depth=1 --branch ${{matrix.repo_branch}}
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix credo tmp/${{matrix.repo_branch}} --strict --mute-exit-status
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
   test_on_new_project:
     runs-on:
@@ -56,25 +42,15 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4]
+        otp: [24.2]
+        elixir: [1.16]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
-
       - run: ./test/test_phoenix_compatibility.sh
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -23,7 +23,7 @@ jobs:
         repo_branch: ["v1.4", "master"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
@@ -46,7 +46,7 @@ jobs:
         elixir: [1.16]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -23,7 +23,7 @@ jobs:
         repo_branch: ["v1.4", "master"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
@@ -46,7 +46,7 @@ jobs:
         elixir: [1.16]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -1,4 +1,8 @@
 name: "Compatibility: Phoenix"
+
+env:
+  ImageOS: ubuntu22
+
 on:
   push:
     branches:
@@ -6,7 +10,10 @@ on:
 
 jobs:
   test_on_source:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - "run-id=${{ github.run_id }}"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
@@ -42,7 +49,10 @@ jobs:
         if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
   test_on_new_project:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - "run-id=${{ github.run_id }}"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -17,10 +17,10 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21.3.8, 22.3.4, 23.3.4]
-        elixir: [1.11]
+        otp: [24.2.2]
+        elixir: [1.12]
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
-        repo_branch: ["v1.11", "master"]
+        repo_branch: ["v1.12", "master"]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -42,8 +42,8 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21.3.8, 22.3.4, 23.3.4]
-        elixir: [1.11]
+        otp: [24.2.2]
+        elixir: [1.12]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -17,7 +17,7 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21, 22, 23]
+        otp: [21.3.8, 22.3.4, 23.3.4]
         elixir: [1.11]
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.11", "master"]
@@ -42,7 +42,7 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21, 22, 23]
+        otp: [21.3.8, 22.3.4, 23.3.4]
         elixir: [1.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -17,10 +17,10 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [24.2]
-        elixir: [1.16]
+        otp: [21, 22, 23]
+        elixir: [1.11]
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
-        repo_branch: ["v1.4", "master"]
+        repo_branch: ["v1.11", "master"]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -42,8 +42,8 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [24.2]
-        elixir: [1.16]
+        otp: [21, 22, 23]
+        elixir: [1.11]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
As shown [here](https://github.com/surgeventures/credo/pull/2), CI on this repo is completely obsoleted, and `ubuntu-latest` that meant ubuntu-20 originally is incompatible with the version of Elixir and OTP used here.