### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,12 +1,12 @@
 version: 1
-generated_at: 2026-06-11T15:37:37Z
+generated_at: 2026-06-15T13:14:41Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
-      - v2
+      - ee0669bd1cc54295c223e0bb666b733df41de1c5
     occurrences:
-      v2:
+      ee0669bd1cc54295c223e0bb666b733df41de1c5:
         .github/workflows/bugfix-reproducer.yml:
           - jobs.test.steps.[0].uses
         .github/workflows/ci-workflow.yml:

--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -21,7 +21,7 @@ jobs:
         otp: [24.2.2]
         elixir: [1.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         otp: [24.2.2]
         elixir: [1.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -23,7 +23,7 @@ jobs:
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.12", "master"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           otp-version: ${{matrix.otp}}

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -22,7 +22,7 @@ jobs:
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.12", "master"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           otp-version: ${{matrix.otp}}
@@ -45,7 +45,7 @@ jobs:
         otp: [24.2.2]
         elixir: [1.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           otp-version: ${{matrix.otp}}


### PR DESCRIPTION
## Summary
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA